### PR TITLE
Preserve Haste source timestamps across state saves

### DIFF
--- a/OmniWatch.lua
+++ b/OmniWatch.lua
@@ -5140,9 +5140,9 @@ local function _ow_save_buff_state()
         f:write(string.format('  [%d] = {\n', buff_id))
         for _, s in ipairs(srcs) do
             f:write(string.format(
-                '    { src_kind = %q, src_id = %d, src_name = %q, potency = %s },\n',
+                '    { src_kind = %q, src_id = %d, src_name = %q, potency = %s, cast_time = %s },\n',
                 s.src_kind or '', s.src_id or 0, s.src_name or '',
-                tostring(s.potency or 0)))
+                tostring(s.potency or 0), tostring(s.cast_time or 0)))
         end
         f:write('  },\n')
     end
@@ -9839,6 +9839,7 @@ local function handle_incoming_action(act)
                     src_id   = spell_id,
                     src_name = spell_name,
                     potency  = potency,
+                    cast_time = os.time(),
                 }
                 _ow_buff_sources[33] = kept
                 _ow_save_buff_state()


### PR DESCRIPTION
## Summary

This preserves `cast_time` when OmniWatch saves buff-source state and stamps Haste/Haste II spell sources with the current time.

Without this, magic-haste source records can be restored without timing metadata. The prune logic may then treat a freshly applied Haste/Haste II source as stale before `player.buffs` has caught up, causing OmniWatch to briefly undercount magic haste and stream an inflated `hasteinfo` value to GearSwap.

## Changes

- Include `cast_time` in `_ow_save_buff_state()` output.
- Add `cast_time = os.time()` to Haste/Haste II spell source records.

## Testing

- `luajit -b OmniWatch.lua`
- Live-tested in Windower with Haste II active.
- Confirmed `//ow dumpsources` keeps buff `33 (Haste)` with `spell "Haste II" potency=30`.
- Confirmed no immediate `[OW] prune: bid=33 ... spell:Haste II` line appeared during the test.